### PR TITLE
vendoring libssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 git2 = "0.15"
-libgit2-sys = "0.14"
+libgit2-sys = { version = "0.14", features = ["vendored-openssl"] }
 sha2 = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
**problem**

There is no easy way to use libssl1.1 on ubuntu 22.04.
https://askubuntu.com/questions/1403619/mongodb-install-fails-on-ubuntu-22-04-depends-on-libssl1-1-but-it-is-not-insta

sver is compiled on ubuntu 20.04. this binary can't execute on ubuntu 22.04.

**solution**

statically link libssl.