### PR TITLE
sver can't work with a path with trailing separator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,7 @@ fn split_path_and_profile(value: &str) -> CalculationTarget {
     })
     .unwrap_or_else(|| {
         let regex = Regex::new(&format!("{}$", SEPARATOR_STR)).unwrap();
-        CalculationTarget::new(
-            regex.replace(value, "").to_string(),
-            "default".to_string(),
-        )
+        CalculationTarget::new(regex.replace(value, "").to_string(), "default".to_string())
     })
 }
 


### PR DESCRIPTION
sver can't work properly with the followings cases.

I fixed it with removing it. This is my first time writing Rust. I'm not sure this PR is good in Rust..

## `sver list` can't list path with the separator at the end

```
# file structure
- lib1
  - sver.toml
- lib2
  - test2.txt
```

```
# lib1/sver.toml
[default]
dependencies = [
     "lib2/",
]
```

```
% sver list lib1
lib1/sver.toml # lib2/test2.txt should be included!
```

## `sver validate` reports that the test data of https://github.com/mitoma/sver/issues/62 is invalid

```
% sver validate   
[NG]	lib/sver.toml:[default]    # This should be valid!
		invalid_dependency:["lib/:prof1", "lib/:prof2"]
		invalid_exclude:[]
[OK]	lib/sver.toml:[prof1]
[OK]	lib/sver.toml:[prof2]
```