### PR TITLE
Generate sha256sum of archives

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -28,6 +28,9 @@ for TARGET_OS_ARCH in "${TARGET_OS_ARCHES[@]}"; do
   rm -rf "$DIR"
 done
 
+cd "${ARTIFACT_DIR}"
+sha256sum * > SHASUMS256.txt
+
 cd "$REPO_ROOT"
 gh release create "$TAG" --generate-notes
 gh release upload "$TAG" "$ARTIFACT_DIR"/*


### PR DESCRIPTION
This PR creates sha256sum of all archives.

It might be better to add a signature like [node.js](https://github.com/nodejs/node#verifying-binaries),
but simple sha256sum is a good first step for now.