### PR TITLE
Update Ubuntu runner to the latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
         job:
           - target: x86_64-unknown-linux-gnu
             os: linux
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-latest
           - target: x86_64-pc-windows-gnu
             os: windows
             runs-on: windows-latest
@@ -64,7 +64,7 @@ jobs:
         job:
           - target: x86_64-unknown-linux-gnu
             os: linux
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-latest
           - target: x86_64-pc-windows-gnu
             os: windows
             runs-on: windows-latest
@@ -73,7 +73,7 @@ jobs:
             runs-on: macos-latest
           - target: aarch64-unknown-linux-gnu
             os: linux
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos
             runs-on: macos-latest
@@ -126,7 +126,7 @@ jobs:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     needs: [build_artifact]
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We can't use 20.04 anymore. Other OS runners use latest so can we use ubuntu-latest too?
