### PR TITLE
ci: scope push trigger to main and tags to avoid duplicate PR runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,12 @@
-name: "Continuous Integration"
+name: Continuous Integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Change the workflow trigger from `on: [push, pull_request]` to a scoped
push trigger. Previously, pushing to a branch with an open PR fired both
`push` and `pull_request`, running the build job twice for the same commit.
